### PR TITLE
Fix the admin interface when WooCommerce too old or not enabled

### DIFF
--- a/woocommerce-payforpayment.php
+++ b/woocommerce-payforpayment.php
@@ -66,8 +66,8 @@ class Pay4Pay {
 		}
 	}
 	public static function wc_version_notice() {
-		?><div class="error"><p><?php 
-			_e('WooCommerce Pay4Payment requires at least WooCommerce 2.2. Please update!');
+		?><div class="error"><p><?php
+			_e('WooCommerce Pay4Payment requires at least WooCommerce '.$this->required_wc_version.'. Please update!');
 		?></p></div><?php
 	}
 


### PR DESCRIPTION
When WC gets disabled (or just too old), the admin interface just breaks. This ports the code used in the main plugin to deactivate the plugin when WC() is not found.

Bumping the required version to something more recent would be reasonable thing to do as well, but I'll leave that for your discretion.