### PR TITLE
2021-06-09 add setting filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Previous versions have been created by [Jörn Lund](https://github.com/mcguffin)
 
 Unreleased updates
 ------------------
-* none
+* New filter introduced `woocommerce_pay4pay_get_current_gateway_settings`
 
 ## Credits
 
@@ -71,6 +71,11 @@ Handle if a payment fee on a specific payment method should be applied. If you w
 	}
 	$current_gateway_id = 'cod';
 	add_filter( "woocommerce_pay4pay_applyfor_{$current_gateway_id}", 'my_pay4pay_apply' , 10 , 4 );
+
+
+#### Filter `woocommerce_pay4pay_get_current_gateway_settings`
+
+Allows you to modify the current gateway settings before the fee calculation - in pretty edge cases that allows you to change tax rate dynamically
 
 #### FAQ ####
 

--- a/inc/class-pay4pay.php
+++ b/inc/class-pay4pay.php
@@ -283,7 +283,7 @@ jQuery(document).ready(function($){
 		if ( $current_gateway = $this->get_current_gateway() ) {
 			$defaults = self::get_default_settings();
 			$settings = $current_gateway->settings + $defaults;
-			return $settings;
+			return apply_filters('woocommerce_pay4pay_get_settings', $settings, $current_gateway);
 		}
 		return false;
 	}

--- a/inc/class-pay4pay.php
+++ b/inc/class-pay4pay.php
@@ -283,7 +283,7 @@ jQuery(document).ready(function($){
 		if ( $current_gateway = $this->get_current_gateway() ) {
 			$defaults = self::get_default_settings();
 			$settings = $current_gateway->settings + $defaults;
-			return apply_filters('woocommerce_pay4pay_get_settings', $settings, $current_gateway);
+			return apply_filters('woocommerce_pay4pay_get_current_gateway_settings', $settings, $current_gateway);
 		}
 		return false;
 	}


### PR DESCRIPTION
if woocommerce official no offer a 'inherit' tax class opcion, give us a hook to return dynamic $settings['pay4pay_includes_taxes'].