### PR TITLE
Fix $cost rounding

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -100,6 +100,10 @@ Either post it on [GitHub](https://github.com/vyskoczilova/woocommerce-payforpay
 
 == Changelog ==
 
+= 2.1.2 (2021-08-19) =
+
+* Fix - cost rounding (use `wc_get_rounding_precision()`) - thanks to [morvy](https://github.com/morvy)
+
 = 2.1.1 (2021-08-17) =
 
 * Fix - check if array passe in gateway settings (fixes [Mercadopago error](https://wordpress.org/support/topic/fatal-error-mercado-pago-compatibility/))

--- a/inc/class-pay4pay.php
+++ b/inc/class-pay4pay.php
@@ -226,7 +226,7 @@ jQuery(document).ready(function($){
 						}
 
 						$cost = apply_filters( "woocommerce_pay4pay_{$current_gateway->id}_amount", $cost, $calculation_base, $current_gateway, $taxable, $include_taxes, $tax_class );
-						$cost = round($cost, \wc_get_price_decimals());
+						$cost = round($cost, \wc_get_rounding_precision());
 
 						$this->_fee = (object) array(
 							'fee_title' => $fee_title,


### PR DESCRIPTION
Correctly use rounding precision for fee `$cost`. Round should be used with `wc_get_rounding_precision()` which returns `wc_get_price_decimals() + 2`