### PR TITLE
Fix tax class when "taxes by cart items" is on

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Previous versions have been created by [Jörn Lund](https://github.com/mcguffin)
 Unreleased updates
 ------------------
 
-- none
+* Fix - tax class when taxes by cart items is on - applies the highest used tax. Thanks to [morvy](https://github.com/morvy)
 
 ## Credits
 

--- a/inc/class-pay4pay.php
+++ b/inc/class-pay4pay.php
@@ -215,6 +215,8 @@ jQuery(document).ready(function($){
 
 						// WooCommerce Fee is always ex taxes. We need to subtract taxes, WC will add them again later.
 						if ( $taxable && $include_taxes ) {
+
+							// Apply the highest tax in the cart (see #65)
 							if ( $tax_class === 'inherit' ) {
 								$highestTaxRate = 0;
 								if ( $cart->get_cart() ) {
@@ -224,7 +226,7 @@ jQuery(document).ready(function($){
 										} else {
 											$itemTaxRate = $item['line_tax'] / $item['line_total'];
 										}
-										
+
 										if ( $itemTaxRate >= $highestTaxRate ) {
 											$highestTaxRate = $itemTaxRate;
 											$tax_class = $item['data']->tax_class;
@@ -232,7 +234,7 @@ jQuery(document).ready(function($){
 									}
 								}
 							}
-							
+
 							$tax_rates = WC_Tax::get_rates( $tax_class );
 
 							$factor = 1;

--- a/inc/class-pay4pay.php
+++ b/inc/class-pay4pay.php
@@ -215,7 +215,24 @@ jQuery(document).ready(function($){
 
 						// WooCommerce Fee is always ex taxes. We need to subtract taxes, WC will add them again later.
 						if ( $taxable && $include_taxes ) {
-
+							if ( $tax_class === 'inherit' ) {
+								$highestTaxRate = 0;
+								if ( $cart->get_cart() ) {
+									foreach ( $cart->get_cart() as $item ) {
+										if ( !$item['line_tax'] || !$item['line_total'] ) {
+											$itemTaxRate = 0;
+										} else {
+											$itemTaxRate = $item['line_tax'] / $item['line_total'];
+										}
+										
+										if ( $itemTaxRate >= $highestTaxRate ) {
+											$highestTaxRate = $itemTaxRate;
+											$tax_class = $item['data']->tax_class;
+										}
+									}
+								}
+							}
+							
 							$tax_rates = WC_Tax::get_rates( $tax_class );
 
 							$factor = 1;


### PR DESCRIPTION
When you set tax class by cart items, it won't apply correct tax class. For example you have 10% and 21% tax, it applies 10% tax instead of 21% tax. This fix addresses this by looping through all products in the cart (when tax is set to inherit/ by cart items) and applies the highest tax class.