### PR TITLE
Fix tax class selection in dropdown not updating #73

### DIFF
--- a/inc/class-pay4pay-admin.php
+++ b/inc/class-pay4pay-admin.php
@@ -329,9 +329,10 @@ class Pay4Pay_Admin {
 		return $default;
 	}
 
-	private function _sanitize_tax_class( $tax_option, $default = 'incl' ) {
-		if ( in_array( $tax_option, array( 0, 'incl', 'excl' ) ) )
+	private function _sanitize_tax_class( $tax_option, $default = 'inherit' ) {
+		if ( array_key_exists( $tax_option, wc_get_product_tax_class_options() ) )
 			return $tax_option;
+	
 		return $default;
 	}
 


### PR DESCRIPTION
This pull request fixes an issue where users were unable to persistently select a tax class from the dropdown menu in the plugin settings. The selection would revert to the default option after saving due to a problem with how the tax class values were being handled.

**Issue Related:** This pull request refers to #73 

I welcome any feedback on these changes and look forward to your review. 