### PR TITLE
Release 2.2.2

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -10,3 +10,4 @@ README.md
 .claude
 CLAUDE.md
 /scripts
+Makefile

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: version-bump release
+
+# Bump version number
+version-bump:
+	@bash scripts/version-bump.sh
+
+# Create a GitHub release from the current plugin version
+release:
+	@bash scripts/release.sh

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://paypal.me/KarolinaVyskocilova
 Tags: ecommerce, woocommerce, payment gateway, fee
 Requires at least: 4.6
 Tested up to: 6.7
-Stable tag: 2.2.2
+Stable tag: 2.2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -121,6 +121,7 @@ Either post it on [GitHub](https://github.com/vyskoczilova/woocommerce-payforpay
 
 = 2.2.2 (2025-11-13) =
 * Fix: Undefined array key warnings for pay4pay_charges_minimum and pay4pay_charges_maximum in settings tab, fixes [this forum issue](https://wordpress.org/support/topic/unidened-pay4pay_charges-minimum/).
+* Fix: Use proper getter method for product tax_class to avoid WooCommerce deprecation warning.
 
 = 2.2.1 (2025-11-13) =
 * Fix: Centralized settings tab now correctly displays payment fee values.

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://paypal.me/KarolinaVyskocilova
 Tags: ecommerce, woocommerce, payment gateway, fee
 Requires at least: 4.6
 Tested up to: 6.7
-Stable tag: 2.2.1
+Stable tag: 2.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -118,6 +118,9 @@ Either post it on [GitHub](https://github.com/vyskoczilova/woocommerce-payforpay
 
 
 == Changelog ==
+
+= 2.2.2 (2025-11-13) =
+* Fix: Undefined array key warnings for pay4pay_charges_minimum and pay4pay_charges_maximum in settings tab, fixes [this forum issue](https://wordpress.org/support/topic/unidened-pay4pay_charges-minimum/).
 
 = 2.2.1 (2025-11-13) =
 * Fix: Centralized settings tab now correctly displays payment fee values.

--- a/README.txt
+++ b/README.txt
@@ -3,8 +3,8 @@ Contributors: vyskoczilova, podpirate
 Donate link: https://paypal.me/KarolinaVyskocilova
 Tags: ecommerce, woocommerce, payment gateway, fee
 Requires at least: 4.6
-Tested up to: 6.7
-Stable tag: 2.2.1
+Tested up to: 6.9
+Stable tag: 2.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -119,9 +119,11 @@ Either post it on [GitHub](https://github.com/vyskoczilova/woocommerce-payforpay
 
 == Changelog ==
 
-= 2.2.2 (2025-11-13) =
+= 2.2.2 (2026-03-18) =
+* Fix: Restore broken `woocommerce_pay4pay_get_current_gateway_settings` filter (broken since 2.1.0 by accidental find-and-replace).
 * Fix: Undefined array key warnings for pay4pay_charges_minimum and pay4pay_charges_maximum in settings tab, fixes [this forum issue](https://wordpress.org/support/topic/unidened-pay4pay_charges-minimum/).
 * Fix: Use proper getter method for product tax_class to avoid WooCommerce deprecation warning.
+* Fix: Replace deprecated `global $woocommerce` usage with `WC()` singleton.
 
 = 2.2.1 (2025-11-13) =
 * Fix: Centralized settings tab now correctly displays payment fee values.

--- a/inc/class-pay4pay-admin.php
+++ b/inc/class-pay4pay-admin.php
@@ -387,7 +387,7 @@ class Pay4Pay_Admin {
 		/**
 		 * Filter to determine if admin footer text should be displayed.
 		 *
-		 * @since 2.5.8
+		 * @since 2.2.1
 		 *
 		 * @param bool $is_plugin_page Whether the current page is a plugin page.
 		 */

--- a/inc/class-pay4pay-admin.php
+++ b/inc/class-pay4pay-admin.php
@@ -330,10 +330,6 @@ class Pay4Pay_Admin {
 		return isset( $_POST[ $key ] ) && $_POST[ $key ] === '1' ? 'yes' : 'no';
 	}
 
-	private function _get_float( $key ) {
-		return isset( $_POST[ $key ] ) && $_POST[ $key ] === '1' ? 'yes' : 'no';
-	}
-
 	/*
 	Handline columns in Woocommerce > settings > checkout
 	*/

--- a/inc/class-pay4pay.php
+++ b/inc/class-pay4pay.php
@@ -241,7 +241,7 @@ jQuery(document).ready(function($){
 
 										if ( $itemTaxRate >= $highestTaxRate ) {
 											$highestTaxRate = $itemTaxRate;
-											$tax_class = $item['data']->tax_class;
+											$tax_class = $item['data']->get_tax_class();
 										}
 									}
 								}

--- a/inc/class-pay4pay.php
+++ b/inc/class-pay4pay.php
@@ -22,6 +22,8 @@ class Pay4Pay {
 			'pay4pay_item_title' => __( 'Extra Charge', 'woocommerce-pay-for-payment' ),
 			'pay4pay_charges_fixed' => 0,
 			'pay4pay_charges_percentage' => 0,
+			'pay4pay_charges_minimum' => 0,
+			'pay4pay_charges_maximum' => 0,
 			'pay4pay_disable_on_free_shipping' => 'no',
 			'pay4pay_disable_on_zero_shipping' => 'no',
 

--- a/inc/class-pay4pay.php
+++ b/inc/class-pay4pay.php
@@ -314,7 +314,7 @@ jQuery(document).ready(function($){
 		if ( $current_gateway = $this->get_current_gateway() ) {
 			$defaults = self::get_default_settings();
 			$settings = $current_gateway->settings + $defaults;
-			return apply_filters('(float) ', $settings, $current_gateway);
+			return apply_filters('woocommerce_pay4pay_get_current_gateway_settings', $settings, $current_gateway);
 		}
 		return false;
 	}

--- a/inc/class-pay4pay.php
+++ b/inc/class-pay4pay.php
@@ -144,8 +144,7 @@ jQuery(document).ready(function($){
 			 * https://docs.woocommerce.com/document/class-reference/#section-5
 			 * @version 2.0.8
 			 */
-			global $woocommerce;
-			if ( $woocommerce->customer->is_vat_exempt() ) {
+			if ( WC()->customer->is_vat_exempt() ) {
 				$taxable = false;
 			}
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -e
+
+PLUGIN_FILE="woocommerce-payforpayment.php"
+README_FILE="readme.txt"
+
+# --- 1. Check for uncommitted changes ---
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Error: You have uncommitted changes. Commit or stash them first."
+    exit 1
+fi
+
+# --- 2. Push all changes ---
+echo "Pushing changes to remote..."
+git push
+
+# --- 3. Get current plugin version ---
+plugin_version=$(grep -E "^[[:space:]]*\*?[[:space:]]*Version:" "$PLUGIN_FILE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+if [ -z "$plugin_version" ]; then
+    echo "Error: Could not detect version from $PLUGIN_FILE"
+    exit 1
+fi
+echo "Plugin version: $plugin_version"
+
+# --- 4. Get latest release tag ---
+latest_tag=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+if [ -z "$latest_tag" ]; then
+    echo "No existing releases found. Will create first release."
+else
+    echo "Latest release:  $latest_tag"
+fi
+
+# --- 5. Compare versions ---
+if [ "$plugin_version" = "$latest_tag" ]; then
+    echo ""
+    echo "Error: Plugin version ($plugin_version) matches the latest release ($latest_tag)."
+    echo "Run 'make version-bump' first."
+    exit 1
+fi
+
+echo ""
+echo "New release: $plugin_version (previous: ${latest_tag:-none})"
+echo ""
+
+# --- 6. Extract changelog entry using Claude CLI ---
+echo "Extracting changelog entry with Claude..."
+echo ""
+
+changelog=$(claude --print --model claude-haiku-4-5-20251001 -p "Read the file $README_FILE. Extract ONLY the changelog entry for version $plugin_version. Output the raw text content of that single version entry (the bullet points only, no heading, no version number). Do not add any commentary.")
+
+if [ -z "$changelog" ]; then
+    echo "Error: Could not extract changelog entry for version $plugin_version"
+    exit 1
+fi
+
+echo "--- Release notes for $plugin_version ---"
+echo ""
+echo "$changelog"
+echo ""
+echo "-------------------------------------------"
+echo ""
+
+# --- 7. Let user review and confirm ---
+read -p "Create GitHub release $plugin_version with these notes? (y/n): " confirm
+
+if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+    echo "Release aborted."
+    exit 0
+fi
+
+# --- 8. Create the tag and GitHub release ---
+echo ""
+echo "Creating GitHub release $plugin_version..."
+
+gh release create "$plugin_version" \
+    --title "$plugin_version" \
+    --notes "$changelog" \
+    --target "$(git rev-parse HEAD)"
+
+echo ""
+echo "Release $plugin_version created successfully!"
+echo "View at: $(gh release view "$plugin_version" --json url --jq '.url')"

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -13,7 +13,7 @@ increment_version() {
     echo "$major.$minor.$patch"
 }
 
-# Get current version from phone-validator-and-formatter.php
+# Get current version from woocommerce-payforpayment.php
 current_version=$(grep -o "Version: [0-9]\+\.[0-9]\+\.[0-9]\+" woocommerce-payforpayment.php | cut -d' ' -f2)
 echo "Current version: $current_version"
 
@@ -24,7 +24,7 @@ if [ -z "$new_version" ]; then
     new_version=$(increment_version $current_version)
 fi
 
-# Update version in phone-validator-and-formatter.php
+# Update version in woocommerce-payforpayment.php
 sed -i '' "s/Version: $current_version/Version: $new_version/" woocommerce-payforpayment.php
 # Update the define() statement for PAY4PAYMENT_VERSION in woocommerce-payforpayment.php
 sed -i '' "s/define( 'PAY4PAYMENT_VERSION', '$current_version' );/define( 'PAY4PAYMENT_VERSION', '$new_version' );/" woocommerce-payforpayment.php
@@ -32,9 +32,10 @@ sed -i '' "s/define( 'PAY4PAYMENT_VERSION', '$current_version' );/define( 'PAY4P
 echo "Updated version to $new_version in woocommerce-payforpayment.php"
 
 # Ask about updating readme.txt
-read -p "Do you want to update the stable tag in readme.txt? (y/n): " update_readme
+read -p "Update the stable tag in readme.txt? (default: yes, Y/n): " update_readme
+update_readme=${update_readme:-Y}
 
-if [ "$update_readme" = "y" ] || [ "$update_readme" = "Y" ]; then
+if [ "$update_readme" != "n" ] && [ "$update_readme" != "N" ]; then
     if [ -f "readme.txt" ]; then
         # Update the stable tag line
         sed -i '' "s/^Stable tag: .*/Stable tag: $new_version/" readme.txt

--- a/woocommerce-payforpayment.php
+++ b/woocommerce-payforpayment.php
@@ -3,7 +3,7 @@
 Plugin Name: Pay for Payment for WooCommerce
 Plugin URI: https://kybernaut.cz/pluginy/woocommerce-pay-for-payment/
 Description: Setup individual charges for each payment method in WooCommerce.
-Version: 2.2.2
+Version: 2.2.2-rc-1
 Author: Karolína Vyskočilová
 Author URI: https://kybernaut.cz
 License: GPL-2.0+
@@ -17,7 +17,7 @@ WC tested up to: 10.3.5
 /**
  * Version of the plugin.
  */
-define( 'PAY4PAYMENT_VERSION', '2.2.2' );
+define( 'PAY4PAYMENT_VERSION', '2.2.2-rc-1' );
 
 /**
  * Check if WooCommerce is active.

--- a/woocommerce-payforpayment.php
+++ b/woocommerce-payforpayment.php
@@ -3,7 +3,7 @@
 Plugin Name: Pay for Payment for WooCommerce
 Plugin URI: https://kybernaut.cz/pluginy/woocommerce-pay-for-payment/
 Description: Setup individual charges for each payment method in WooCommerce.
-Version: 2.2.1
+Version: 2.2.2
 Author: Karolína Vyskočilová
 Author URI: https://kybernaut.cz
 License: GPL-2.0+
@@ -17,7 +17,7 @@ WC tested up to: 10.3.5
 /**
  * Version of the plugin.
  */
-define( 'PAY4PAYMENT_VERSION', '2.2.1' );
+define( 'PAY4PAYMENT_VERSION', '2.2.2' );
 
 /**
  * Check if WooCommerce is active.

--- a/woocommerce-payforpayment.php
+++ b/woocommerce-payforpayment.php
@@ -3,7 +3,7 @@
 Plugin Name: Pay for Payment for WooCommerce
 Plugin URI: https://kybernaut.cz/pluginy/woocommerce-pay-for-payment/
 Description: Setup individual charges for each payment method in WooCommerce.
-Version: 2.2.2-rc-1
+Version: 2.2.2
 Author: Karolína Vyskočilová
 Author URI: https://kybernaut.cz
 License: GPL-2.0+
@@ -11,13 +11,13 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.txt
 Text Domain: woocommerce-pay-for-payment
 Domain Path: /languages
 WC requires at least: 2.6
-WC tested up to: 10.3.5
+WC tested up to: 10.6.1
 */
 
 /**
  * Version of the plugin.
  */
-define( 'PAY4PAYMENT_VERSION', '2.2.2-rc-1' );
+define( 'PAY4PAYMENT_VERSION', '2.2.2' );
 
 /**
  * Check if WooCommerce is active.


### PR DESCRIPTION
## Summary
- Fix: Restore broken `woocommerce_pay4pay_get_current_gateway_settings` filter (broken since 2.1.0)
- Fix: Remove unused `_get_float()` method
- Fix: Correct `@since` tag for admin footer text filter
- Fix: Replace deprecated `global $woocommerce` with `WC()` singleton
- Bump version to 2.2.2, WP tested up to 6.9, WC tested up to 10.6.1